### PR TITLE
Adapt to artemis4j changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>edu.kit.kastel.sdq</groupId>
       <artifactId>artemis4j</artifactId>
-      <version>8.0.0</version>
+      <version>8.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jcommander</groupId>

--- a/src/main/java/edu/kit/kastel/sdq/scorestats/cli/CLI.java
+++ b/src/main/java/edu/kit/kastel/sdq/scorestats/cli/CLI.java
@@ -26,7 +26,6 @@ import edu.kit.kastel.sdq.artemis4j.grading.Course;
 import edu.kit.kastel.sdq.artemis4j.grading.Exercise;
 import edu.kit.kastel.sdq.artemis4j.grading.PackedAssessment;
 import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingExercise;
-import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmission;
 import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmissionWithResults;
 import edu.kit.kastel.sdq.artemis4j.grading.metajson.AnnotationMappingException;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig;


### PR DESCRIPTION
Right now this is the bare minimum to make artemis-stats work with the changes to Artemis4j. Ideally, we would have a few new features related to exams and the review round, such as:
- Show the mistake types that where suppressed most often during review
- Show the assessors for whom the most annotations where suppressed
- Show all students who got additional points during review or who had their assessment changed during review